### PR TITLE
Distribute COPYRIGHT with the tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include COPYRIGHT


### PR DESCRIPTION
Greetings!

I've added a MANIFEST.in.  If this is present, then the next time you run `python setup.py sdist`, distutils will hardlink the COPYRIGHT file into the tarball.  As it stands now, the COPYRIGHT file won't actually make it to PyPI on the next release (I think).

Cheers-
 -Ralph
