### PR TITLE
show if a logger is disabled

### DIFF
--- a/logging_tree/format.py
+++ b/logging_tree/format.py
@@ -55,6 +55,8 @@ def describe(node):
             yield '   Level ' + logging.getLevelName(logger.level)
         if not logger.propagate:
             yield '   Propagate OFF'
+        if logger.disabled:
+            yield '   Disabled'
 
         # In case someone has defined a custom logger that lacks a
         # `filters` or `handlers` attribute, we call getattr() and

--- a/logging_tree/tests/test_format.py
+++ b/logging_tree/tests/test_format.py
@@ -69,6 +69,7 @@ class FormatTests(LoggingTestCase):
         log = logging.getLogger('db')
         log.setLevel(logging.INFO)
         log.propagate = False
+        log.disabled = 1
         log.addFilter(MyFilter())
 
         handler = logging.StreamHandler()
@@ -90,6 +91,7 @@ class FormatTests(LoggingTestCase):
    o   "db"
    |   Level INFO
    |   Propagate OFF
+   |   Disabled
    |   Filter <MyFilter>
    |   Handler Stream %r
    |     Filter name='db.errors'


### PR DESCRIPTION
While the logging docs don't discuss the `disabled` attribute, its there and can sure throw a wrench in debugging your logging config.
