### PR TITLE
Use parent attribute to find inheritance chain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /.tox/
 *.pyc
+/*.egg-info/

--- a/logging_tree/format.py
+++ b/logging_tree/format.py
@@ -37,38 +37,33 @@ def describe(node):
 
     """
     logger = node[1]
-    is_placeholder = isinstance(logger, logging.PlaceHolder)
-    if is_placeholder or logger.propagate:
+    if logger.propagate:
         arrow = '<--'
     else:
         arrow = '   '
-    if is_placeholder:
-        name = '[%s]' % node[0]
-    else:
-        name = '"%s"' % node[0]
+    name = '"%s"' % node[0]
     yield arrow + name
-    if not is_placeholder:
-        if logger.level == logging.NOTSET:
-            yield '   Level NOTSET so inherits level ' + logging.getLevelName(
-                logger.getEffectiveLevel())
-        else:
-            yield '   Level ' + logging.getLevelName(logger.level)
-        if not logger.propagate:
-            yield '   Propagate OFF'
-        if logger.disabled:
-            yield '   Disabled'
+    if logger.level == logging.NOTSET:
+        yield '   Level NOTSET so inherits level ' + logging.getLevelName(
+            logger.getEffectiveLevel())
+    else:
+        yield '   Level ' + logging.getLevelName(logger.level)
+    if not logger.propagate:
+        yield '   Propagate OFF'
+    if logger.disabled:
+        yield '   Disabled'
 
-        # In case someone has defined a custom logger that lacks a
-        # `filters` or `handlers` attribute, we call getattr() and
-        # provide an empty sequence as a fallback.
+    # In case someone has defined a custom logger that lacks a
+    # `filters` or `handlers` attribute, we call getattr() and
+    # provide an empty sequence as a fallback.
 
-        for f in getattr(logger, 'filters', ()):
-            yield '   Filter %s' % describe_filter(f)
-        for h in getattr(logger, 'handlers', ()):
-            g = describe_handler(h)
-            yield '   Handler %s' % next(g)
-            for line in g:
-                yield '   ' + line
+    for f in getattr(logger, 'filters', ()):
+        yield '   Filter %s' % describe_filter(f)
+    for h in getattr(logger, 'handlers', ()):
+        g = describe_handler(h)
+        yield '   Handler %s' % next(g)
+        for line in g:
+            yield '   ' + line
 
     children = node[2]
     if children:

--- a/logging_tree/tests/test_format.py
+++ b/logging_tree/tests/test_format.py
@@ -59,10 +59,8 @@ class FormatTests(LoggingTestCase):
    |   o<--"a.b"
    |       Level DEBUG
    |
-   o<--[x]
-       |
-       o<--"x.c"
-           Level NOTSET so inherits level WARNING
+   o<--"x.c"
+       Level NOTSET so inherits level WARNING
 ''')
 
     def test_fancy_tree(self):
@@ -106,12 +104,10 @@ class FormatTests(LoggingTestCase):
    |   o<--"db.stats"
    |       Level NOTSET so inherits level INFO
    |
-   o<--[www]
-       |
-       o<--"www.status"
-           Level DEBUG
-           Handler File '/foo/log.txt'
-           Handler <MyHandler>
+   o<--"www.status"
+       Level DEBUG
+       Handler File '/foo/log.txt'
+       Handler <MyHandler>
 ''' % (sys.stderr,))
 
     def test_most_handlers(self):

--- a/logging_tree/tests/test_node.py
+++ b/logging_tree/tests/test_node.py
@@ -5,12 +5,6 @@ import unittest
 from logging_tree.nodes import tree
 from logging_tree.tests.case import LoggingTestCase
 
-class AnyPlaceHolder(object):
-    def __eq__(self, other):
-        return isinstance(other, logging.PlaceHolder)
-
-any_placeholder = AnyPlaceHolder()
-
 class NodeTests(LoggingTestCase):
 
     def test_default_tree(self):
@@ -36,12 +30,23 @@ class NodeTests(LoggingTestCase):
                     ]))
 
     def test_two_level_tree_with_placeholder(self):
+        # Place holders are now ignored in tree view
         b = logging.getLogger('a.b')
         self.assertEqual(tree(), (
                 '', logging.root, [
-                    ('a', any_placeholder, [
-                            ('a.b', b, []),
-                            ]),
+                    ('a.b', b, []),
+                    ]))
+
+    def test_overridden_parent(self):
+        a = logging.getLogger('a')
+        b = logging.getLogger('b')
+        b.parent = a
+
+        self.assertEqual(tree(), (
+                '', logging.root, [
+                    ('a', a, [
+                        ('b', b, []),
+                        ]),
                     ]))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py24, py25, py26, py27, py32, py33
+envlist = py24, py25, py26, py27, py32, py33, py34
 [testenv]
 commands = python -m unittest discover logging_tree
 [testenv:py24]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,8 @@
 [tox]
 envlist = py24, py25, py26, py27, py32, py33, py34
 [testenv]
-commands = python -m unittest discover logging_tree
-[testenv:py24]
-deps = unittest2
-commands = unit2 discover logging_tree
-[testenv:py25]
-deps = unittest2
-commands = unit2 discover logging_tree
-[testenv:py26]
-deps = unittest2
-commands = unit2 discover logging_tree
+deps =
+    py2{4,5,6}: unittest2
+commands =
+    py{27,32,33,34}: python -m unittest discover logging_tree
+    py2{4,5,6}: unit2 discover logging_tree


### PR DESCRIPTION
Fixes #13

While not documented, loggers have a `parent` attribute that determines the inheritance chain. In this inheritance chain there are no placeholder loggers, but the parent may be re-assigned by manually assigning a different logger to the `parent` attribute.

To better reflect how the module actually operates, we need to be following that `parent` attribute, rather than parsing the names. This means that there will be no placeholders in the output, because the `parent` never points to a placeholder, but rather skips over it entirely.