### PR TITLE
Pass along args and kwargs to print in printout

### DIFF
--- a/logging_tree/format.py
+++ b/logging_tree/format.py
@@ -7,14 +7,14 @@ if sys.version_info < (2, 6):
     next = lambda generator: generator.next()  # supply a missing builtin
 
 
-def printout(node=None):
+def printout(*args, node=None, **kwargs):
     """Print a tree of loggers, given a `Node` from `logging_tree.nodes`.
 
     If no `node` argument is provided, then the entire tree of currently
     active `logging` loggers is printed out.
 
     """
-    print(build_description(node)[:-1])
+    print(build_description(node)[:-1], *args, **kwargs)
 
 
 def build_description(node=None):


### PR DESCRIPTION
Hi Brandon!

Do you think this could work?

I would like to be able to pass along file=sys.stderr so I can have a debug mode in my application that prints the logging tree to stderr.