### PR TITLE
Fix parent name getting

### DIFF
--- a/logging_tree/format.py
+++ b/logging_tree/format.py
@@ -62,7 +62,7 @@ def _describe(node, parent):
         yield '%s"%s"' % (arrow, name)
         if not parent_is_correct:
             yield ('   Broken .parent! Messages propagate to "%s"'
-                   % logger.parent.name)
+                   % getattr(logger.parent, 'name', "None"))
         if logger.level == logging.NOTSET:
             yield '   Level NOTSET so inherits level ' + logging.getLevelName(
                 logger.getEffectiveLevel())

--- a/logging_tree/format.py
+++ b/logging_tree/format.py
@@ -61,8 +61,8 @@ def _describe(node, parent):
             arrow = ' !-'
         yield '%s"%s"' % (arrow, name)
         if not parent_is_correct:
-            yield ('   Broken .parent! Messages propagate to "%s"'
-                   % getattr(logger.parent, 'name', "None"))
+            yield ('   Broken .parent! Messages propagate to %r'
+                   % getattr(logger.parent, 'name', None))
         if logger.level == logging.NOTSET:
             yield '   Level NOTSET so inherits level ' + logging.getLevelName(
                 logger.getEffectiveLevel())


### PR DESCRIPTION
* Some modules tend to set logger.parent to None, to
  achieve root-logger independence. This fix allows to
  use logging_tree in such cases.