### PR TITLE
WIP: Add logic to trim unimportant loggers from tree

### DIFF
--- a/logging_tree/nodes.py
+++ b/logging_tree/nodes.py
@@ -27,12 +27,16 @@ def tree(trim=False):
     return root
 
 
-def trim_tree(node=None):
+def trim_tree(node=None, trim_nullhandlers=True):
     """Remove nodes that don't modify any logging configuration from tree."""
     if node is None:
         node = tree()
     name, logger, children = node
     children = list(filter(None, map(trim_tree, children)))
+    handlers = getattr(logger, 'handlers', ())
+    if trim_nullhandlers:
+        handlers = [handler for handler in handlers
+                    if not isinstance(handler, logging.NullHandler)]
     if (
         not children
         and (
@@ -42,7 +46,7 @@ def trim_tree(node=None):
                 and logger.propagate
                 and logger.level == logging.NOTSET
                 and not getattr(logger, 'filters', ())
-                and not getattr(logger, 'handlers', ())
+                and not handlers
             )
         )
     ):

--- a/logging_tree/tests/test_node.py
+++ b/logging_tree/tests/test_node.py
@@ -44,6 +44,44 @@ class NodeTests(LoggingTestCase):
                             ]),
                     ]))
 
+    def test_default_trim_tree(self):
+        self.assertEqual(tree(trim=True), ('', logging.root, []))
+
+    def test_one_level_trim_tree(self):
+        a = logging.getLogger('a')
+        b = logging.getLogger('b')
+        b.setLevel(logging.INFO)
+        self.assertEqual(tree(trim=True), (
+                '', logging.root, [
+                    ('b', b, []),
+                    ]))
+
+    def test_two_level_trim_tree(self):
+        a = logging.getLogger('a')
+        a.setLevel(logging.INFO)
+        b = logging.getLogger('a.b')
+        c = logging.getLogger('c')
+        d = logging.getLogger('c.d')
+        d.setLevel(logging.INFO)
+        self.assertEqual(tree(trim=True), (
+                '', logging.root, [
+                    ('a', a, []),
+                    ('c', c, [
+                            ('c.d', d, []),
+                            ]),
+                    ]))
+
+    def test_two_level_trim_tree_with_placeholder(self):
+        b = logging.getLogger('a.b')
+        d = logging.getLogger('c.d')
+        d.setLevel(logging.INFO)
+        self.assertEqual(tree(trim=True), (
+                '', logging.root, [
+                    ('c', any_placeholder, [
+                            ('c.d', d, []),
+                            ]),
+                    ]))
+
 
 if __name__ == '__main__':  # for Python <= 2.4
     unittest.main()

--- a/logging_tree/tests/test_node.py
+++ b/logging_tree/tests/test_node.py
@@ -82,6 +82,25 @@ class NodeTests(LoggingTestCase):
                             ]),
                     ]))
 
+    def test_two_level_trim_tree_with_placeholder_and_nullhandler(self):
+        a = logging.getLogger('a')
+        a.addHandler(logging.StreamHandler())
+        b = logging.getLogger('b')
+        b.addHandler(logging.NullHandler())
+        d = logging.getLogger('c.d')
+        d.addHandler(logging.StreamHandler())
+        f = logging.getLogger('e.f')
+        f.addHandler(logging.NullHandler())
+        g = logging.getLogger('g')
+        g.addHandler(logging.NullHandler())
+        h = logging.getLogger('g.h')
+        h.addHandler(logging.NullHandler())
+        self.assertEqual(tree(trim=True), (
+                '', logging.root, [
+                    ('a', a, []),
+                    ('c', any_placeholder, [('c.d', d, [])]),
+                    ]))
+
 
 if __name__ == '__main__':  # for Python <= 2.4
     unittest.main()


### PR DESCRIPTION
Allows to recursively remove loggers that don't define any settings and
just propagate to higher loggers. This makes it easy to spot loggers
with custom settings.