### PR TITLE
Added a file keyword arg to printout()

### DIFF
--- a/logging_tree/format.py
+++ b/logging_tree/format.py
@@ -16,10 +16,11 @@ def printout(node=None, file=None):
     If a file argument is provided, output will be written to it, 
     otherwise output will go to stdout.
     """
+    description = build_description(node)[:-1]
     if file is None:
-        print(build_description(node)[:-1])
+        print(description)
     else:
-        file.write(build_description(node)[:-1])
+        file.write(description)
         file.write("\n")
 
 

--- a/logging_tree/format.py
+++ b/logging_tree/format.py
@@ -7,14 +7,20 @@ if sys.version_info < (2, 6):
     next = lambda generator: generator.next()  # supply a missing builtin
 
 
-def printout(node=None):
+def printout(node=None, file=None):
     """Print a tree of loggers, given a `Node` from `logging_tree.nodes`.
 
     If no `node` argument is provided, then the entire tree of currently
     active `logging` loggers is printed out.
-
+    
+    If a file argument is provided, output will be written to it, 
+    otherwise output will go to stdout.
     """
-    print(build_description(node)[:-1])
+    if file is None:
+        print(build_description(node)[:-1])
+    else:
+        file.write(build_description(node)[:-1])
+        file.write("\n")
 
 
 def build_description(node=None):


### PR DESCRIPTION
Sometimes sys.stdout isn't easily accessible, so I added a file= keyword arg to printout(), allowing the tree to be printed to sys.stderr or directly into a file.
