### PR TITLE
Create GitHub Actions workflow

### DIFF
--- a/.github/workflows/logging-tree-tests.yml
+++ b/.github/workflows/logging-tree-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]

--- a/.github/workflows/logging-tree-tests.yml
+++ b/.github/workflows/logging-tree-tests.yml
@@ -1,0 +1,24 @@
+name: logging_tree tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Test with unittest
+      run: |
+        python -m unittest logging_tree.tests.test_format logging_tree.tests.test_node


### PR DESCRIPTION
It doesn't look like the Travis CI workflow is running, so I've proposed a GitHub Actions workflow that mirrors what the Travis one did/does.

You can see its output [here on my fork](https://github.com/loganrosen/logging_tree/actions/runs/735142549) (which includes the currently-failing 3.9 build).